### PR TITLE
adding expandable prop and refactoring row component

### DIFF
--- a/src/actions/cryptoMarketCapListActions.ts
+++ b/src/actions/cryptoMarketCapListActions.ts
@@ -3,9 +3,6 @@ import * as constants from '../constants';
 import { CoinDataResponse, FlattenedCoinData, StoreState } from '../types';
 import { Dispatch } from 'redux';
 const cryptoCompare = require('cryptocompare');
-export interface SelectCoinIcon {
-    type: constants.SELECT_COIN_ICON;
-}
 
 export interface FilterListAlphabetically {
     type: constants.FILTER_LIST_ALPHABETICALLY;
@@ -21,11 +18,7 @@ export interface SetAvailableCoinList {
     coinList: string[];
 }
 
-export type CryptoMarketCapListAction = SelectCoinIcon | FilterListAlphabetically | SetCoinData | SetAvailableCoinList;
-
-export const selectCoinIcon = (): SelectCoinIcon => ({
-    type: constants.SELECT_COIN_ICON
-});
+export type CryptoMarketCapListAction = FilterListAlphabetically | SetCoinData | SetAvailableCoinList;
 
 export const filterListAlphabetically = () => ({
     type: constants.FILTER_LIST_ALPHABETICALLY

--- a/src/actions/cryptoMarketCapListRowActions.ts
+++ b/src/actions/cryptoMarketCapListRowActions.ts
@@ -1,0 +1,11 @@
+import * as constants from '../constants';
+
+export interface SelectCoinIcon {
+    type: constants.SELECT_COIN_ICON;
+}
+
+export type CryptoMarketCapListRowAction = SelectCoinIcon;
+
+export const selectCoinIcon = (): SelectCoinIcon => ({
+    type: constants.SELECT_COIN_ICON
+});

--- a/src/components/MarketCapList.tsx
+++ b/src/components/MarketCapList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { FlattenedCoinData } from '../types';
-import { MarketCapListRow } from './MarketCapListRow';
+import { FlattenedCoinData, CoinRow } from '../types';
+import MarketCapListRow from './MarketCapListRow';
 const cryptocurrencies = require('cryptocurrencies');
 
 export interface MarketCapListProps {
@@ -13,38 +13,42 @@ export function MarketCapList({ coinData, handleCoinIconClick, title }: MarketCa
 
   const renderCryptoMarketCapListTableHeader = (): JSX.Element => {
     return (
-      <div className={'flexrow'}>
-        <div className="flexcol-icon">
+      <div className={'flex-row'}>
+        <div className="flex-col-icon">
           <h2 className="item">{''}</h2>
         </div>
-        <div className="flexcol">
+        <div className="flex-col">
           <h2 className="item">{'Ticker'}</h2>
         </div>
-        <div className="flexcol">
+        <div className="flex-col">
           <h2 className="item">{'Full Name'}</h2>
         </div>
-        <div className="flexcol">
+        <div className="flex-col">
           <h2 className="item">{'Total Supply'}</h2>
         </div>
-        <div className="flexcol">
+        <div className="flex-col">
           <h2 className="item">{'Current Price'}</h2>
         </div>
-        <div className="flexcol">
+        <div className="flex-col">
           <h2 className="item">{'Market Cap'}</h2>
         </div>
       </div>
     );
   };
 
+  const mapCoinDataToCoinRow = (coins: FlattenedCoinData[]): CoinRow[] =>
+    coins.map(coin => Object.assign({ coinData: coin, isRowExpanded: false }));
+
   const renderCryptoMarketCapList = (): JSX.Element[] => {
     const cryptoRows = coinData.map((coin, index) => {
+      const coinRow: CoinRow | undefined =
+        mapCoinDataToCoinRow(coinData).find(element => element.coinData.name === coin.name);
       return (
         <MarketCapListRow
-          coinData={coinData}
-          cryptoName={cryptocurrencies[coin.name]}
+          coinRow={coinRow ? coinRow : Object.create({})}
+          cryptoName={(cryptocurrencies[coin.name] as string)}
           cryptoSymbol={coin.name}
           key={coin.name}
-          handleCoinIconClick={handleCoinIconClick}
         />
       );
     });

--- a/src/components/MarketCapList.tsx
+++ b/src/components/MarketCapList.tsx
@@ -45,7 +45,7 @@ export function MarketCapList({ coinData, handleCoinIconClick, title }: MarketCa
         mapCoinDataToCoinRow(coinData).find(element => element.coinData.name === coin.name);
       return (
         <MarketCapListRow
-          coinRow={coinRow ? coinRow : Object.create({})}
+          coinRow={coinRow as CoinRow}
           cryptoName={(cryptocurrencies[coin.name] as string)}
           cryptoSymbol={coin.name}
           key={coin.name}

--- a/src/components/MarketCapListRow.tsx
+++ b/src/components/MarketCapListRow.tsx
@@ -1,89 +1,107 @@
 import * as React from 'react';
-import { FlattenedCoinData } from '../types';
+import { CoinRow } from '../types';
 
 export interface MarketCapListRowProps {
-  coinData: FlattenedCoinData[];
-  handleCoinIconClick?: () => void;
+  coinRow: CoinRow;
   cryptoSymbol: string;
   cryptoName: string;
 }
 
-export function MarketCapListRow(props: MarketCapListRowProps): JSX.Element {
-  const { cryptoSymbol, cryptoName, coinData, handleCoinIconClick } = props;
-  const cryptoIcon = require('../icons/coins/color/' + cryptoSymbol.toLowerCase() + '.svg');
+export interface MarketCapListRowState {
+  isExpanded: boolean;
+  cryptoIcon: string;
+}
 
-  const renderCoinPriceCol = (coinTicker: string): JSX.Element => {
-    const coin: FlattenedCoinData | undefined = coinData.find(element => element.name === coinTicker);
+class MarketCapListRow extends React.Component<MarketCapListRowProps, MarketCapListRowState> {
+
+  constructor(props: MarketCapListRowProps) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+      cryptoIcon: require('../icons/coins/color/' + this.props.cryptoSymbol.toLowerCase() + '.svg')
+    };
+  }
+
+  handleCoinIconClick = (): void => {
+    console.log('smarty');
+    this.setState(prevState => ({
+      isExpanded: !prevState.isExpanded
+    }));
+  }
+
+  renderCoinPriceCol(coinTicker: string): JSX.Element {
     return (
-      <span className={coin ? 'item ' + coin.style : 'item'}>
-        {coin ? coin.USD.PRICE : 'Price Not Found'}
+      <span className={this.props.coinRow ? 'item ' + this.props.coinRow.coinData.style : 'item'}>
+        {this.props.coinRow ? this.props.coinRow.coinData.USD.PRICE : 'Price Not Found'}
       </span>
     );
-  };
+  }
 
-  const renderCryptoMarketCapIcon = (icon: string): JSX.Element => {
+  renderCryptoMarketCapIcon(icon: string): JSX.Element {
     return (
-      <div className="item">
+      <div className="item">`
         <img
           className="icon"
           src={icon}
-          onClick={handleCoinIconClick}
+          onClick={this.handleCoinIconClick}
         />
       </div>
     );
-  };
+  }
 
-  const renderCryptoMarketCapSymbol = (value: string) => {
+  renderCryptoMarketCapSymbol(value: string) {
     return (
       <span className="item">{value}</span>
     );
-  };
+  }
 
-  const renderCryptoName = (value: string): JSX.Element => {
+  renderCryptoName(value: string): JSX.Element {
     return (
       <span className="item">{value}</span>
     );
-  };
+  }
 
-  const renderTotalSupply = (coinTicker: string): JSX.Element => {
-    const coin: FlattenedCoinData | undefined = coinData.find(element => element.name === coinTicker);
+  renderTotalSupply(coinTicker: string): JSX.Element {
     return (
       <span className="item">
-        {coin ? coin.USD.SUPPLY : 'Supply Not Found'}
+        {this.props.coinRow ? this.props.coinRow.coinData.USD.SUPPLY : 'Supply Not Found'}
       </span>
     );
-  };
+  }
 
-  const renderCryptoMarketCapChange = (coinTicker: string): JSX.Element => {
-    const coin: FlattenedCoinData | undefined = coinData.find(element => element.name === coinTicker);
+  renderCryptoMarketCapChange(coinTicker: string): JSX.Element {
     return (
       <span className="item">
-        {coin ? coin.USD.MKTCAP : 'Market Cap Not Found'}
+        {this.props.coinRow ? this.props.coinRow.coinData.USD.MKTCAP : 'Market Cap Not Found'}
       </span>
     );
-  };
+  }
 
-  return (
-    <div className={'flexrow'} key={cryptoName}>
-          <div className="flexcol-icon">
-            {renderCryptoMarketCapIcon(cryptoIcon)}
-          </div>
-          <div className="flexcol">
-            {renderCryptoMarketCapSymbol(cryptoSymbol)}
-          </div>
-          <div className="flexcol">
-            {renderCryptoName(cryptoName)}
-          </div>
-          <div className="flexcol">
-            {renderTotalSupply(cryptoSymbol)}
-          </div>
-          <div className="flexcol">
-            {renderCoinPriceCol(cryptoSymbol)}
-          </div>
-          <div className="flexcol">
-            {renderCryptoMarketCapChange(cryptoSymbol)}
-          </div>
-
+  render() {
+    return (
+      <div className={`flex-row${this.state.isExpanded ? '-expanded' : ''}`} key={this.props.cryptoName}>
+        <div className="flex-col-icon">
+          {this.renderCryptoMarketCapIcon(this.state.cryptoIcon)}
         </div>
-  );
+        <div className="flex-col">
+          {this.renderCryptoMarketCapSymbol(this.props.cryptoSymbol)}
+        </div>
+        <div className="flex-col">
+          {this.renderCryptoName(this.props.cryptoName)}
+        </div>
+        <div className="flex-col">
+          {this.renderTotalSupply(this.props.cryptoSymbol)}
+        </div>
+        <div className="flex-col">
+          {this.renderCoinPriceCol(this.props.cryptoSymbol)}
+        </div>
+        <div className="flex-col">
+          {this.renderCryptoMarketCapChange(this.props.cryptoSymbol)}
+        </div>
+
+      </div>
+    );
+  }
 }
+
+export default MarketCapListRow;

--- a/src/components/MarketCapListRow.tsx
+++ b/src/components/MarketCapListRow.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { CoinRow } from '../types';
+import MarketCapListRowDetailView from './MarketCapListRowDetailView';
 
 export interface MarketCapListRowProps {
   coinRow: CoinRow;
@@ -18,89 +19,100 @@ class MarketCapListRow extends React.Component<MarketCapListRowProps, MarketCapL
     super(props);
     this.state = {
       isExpanded: false,
-      cryptoIcon: require('../icons/coins/color/' + this.props.cryptoSymbol.toLowerCase() + '.svg')
+      cryptoIcon: require(`../icons/coins/color/${this.props.cryptoSymbol.toLowerCase()}.svg`)
     };
   }
 
   handleCoinIconClick = (): void => {
-    console.log('smarty');
     this.setState(prevState => ({
       isExpanded: !prevState.isExpanded
     }));
   }
 
-  renderCoinPriceCol(coinTicker: string): JSX.Element {
+  renderCoinPriceCol = (): JSX.Element => {
     return (
-      <span className={this.props.coinRow ? 'item ' + this.props.coinRow.coinData.style : 'item'}>
-        {this.props.coinRow ? this.props.coinRow.coinData.USD.PRICE : 'Price Not Found'}
+      <span className={this.props.coinRow ? `item ${this.props.coinRow.coinData.style}` : 'item'}>
+        {this.props.coinRow.coinData.USD.PRICE}
       </span>
     );
   }
 
-  renderCryptoMarketCapIcon(icon: string): JSX.Element {
+  renderCryptoMarketCapIcon = (): JSX.Element => {
     return (
-      <div className="item">`
+      <div className="item">
         <img
           className="icon"
-          src={icon}
+          src={this.state.cryptoIcon}
           onClick={this.handleCoinIconClick}
         />
       </div>
     );
   }
 
-  renderCryptoMarketCapSymbol(value: string) {
+  renderCryptoMarketCapSymbol = () => {
     return (
-      <span className="item">{value}</span>
+      <span className="item">{this.props.cryptoSymbol}</span>
     );
   }
 
-  renderCryptoName(value: string): JSX.Element {
+  renderCryptoName = (): JSX.Element => {
     return (
-      <span className="item">{value}</span>
+      <span className="item">{this.props.cryptoName}</span>
     );
   }
 
-  renderTotalSupply(coinTicker: string): JSX.Element {
+  renderTotalSupply = (): JSX.Element => {
     return (
       <span className="item">
-        {this.props.coinRow ? this.props.coinRow.coinData.USD.SUPPLY : 'Supply Not Found'}
+        {this.props.coinRow.coinData.USD.SUPPLY}
       </span>
     );
   }
 
-  renderCryptoMarketCapChange(coinTicker: string): JSX.Element {
+  renderCryptoMarketCapChange = (): JSX.Element => {
     return (
       <span className="item">
-        {this.props.coinRow ? this.props.coinRow.coinData.USD.MKTCAP : 'Market Cap Not Found'}
+        {this.props.coinRow.coinData.USD.MKTCAP}
       </span>
+    );
+  }
+
+  renderBasicCoinColumns = (): JSX.Element => {
+    return (
+      <div className="flex-row">
+        <div className="flex-col-icon">
+          {this.renderCryptoMarketCapIcon()}
+        </div>
+        <div className="flex-col">
+          {this.renderCryptoMarketCapSymbol()}
+        </div>
+        <div className="flex-col">
+          {this.renderCryptoName()}
+        </div>
+        <div className="flex-col">
+          {this.renderTotalSupply()}
+        </div>
+        <div className="flex-col">
+          {this.renderCoinPriceCol()}
+        </div>
+        <div className="flex-col">
+          {this.renderCryptoMarketCapChange()}
+        </div>
+      </div>
+    );
+  }
+
+  renderDetailedView = (): JSX.Element => {
+    return (
+      <div className="crypto-market-cap-list">
+        {this.renderBasicCoinColumns()}
+        <MarketCapListRowDetailView coinRow={this.props.coinRow} />
+      </div>
     );
   }
 
   render() {
-    return (
-      <div className={`flex-row${this.state.isExpanded ? '-expanded' : ''}`} key={this.props.cryptoName}>
-        <div className="flex-col-icon">
-          {this.renderCryptoMarketCapIcon(this.state.cryptoIcon)}
-        </div>
-        <div className="flex-col">
-          {this.renderCryptoMarketCapSymbol(this.props.cryptoSymbol)}
-        </div>
-        <div className="flex-col">
-          {this.renderCryptoName(this.props.cryptoName)}
-        </div>
-        <div className="flex-col">
-          {this.renderTotalSupply(this.props.cryptoSymbol)}
-        </div>
-        <div className="flex-col">
-          {this.renderCoinPriceCol(this.props.cryptoSymbol)}
-        </div>
-        <div className="flex-col">
-          {this.renderCryptoMarketCapChange(this.props.cryptoSymbol)}
-        </div>
-
-      </div>
-    );
+    return this.state.isExpanded ? this.renderDetailedView() : this.renderBasicCoinColumns();
   }
 }
 

--- a/src/components/MarketCapListRowDetailView.tsx
+++ b/src/components/MarketCapListRowDetailView.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import * as React from 'react';
+import { CoinRow } from '../types';
 
 export interface MarketCapListRowDetailViewProps {
-
+    coinRow: CoinRow;
 }
 
 export interface MarketCapListRowDetailViewState {
@@ -14,9 +15,83 @@ class MarketCapListRowDetailView extends
         super(props);
         this.state = {};
     }
+
+    getCoinDetailDataRow = (): JSX.Element => {
+        return (
+            <div className="coin-detail-row">
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.CHANGE24HOUR}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.CHANGEDAY}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.CHANGEPCT24HOUR}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.CHANGEPCTDAY}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.HIGH24HOUR}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.HIGHDAY}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.LASTMARKET}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.LOW24HOUR}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{this.props.coinRow.coinData.USD.LOWDAY}</span>
+                </div>
+            </div>
+        );
+    }
+
+    getCoinDetailHeaderRow = (): JSX.Element => {
+        return (
+            <div className="coin-detail-row">
+                <div className="flex-col">
+                    <span className="item">{'Change 24 Hours'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'Change Day'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'Change % 24 Hours'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'Change % Day'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'High 24 Hours'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'High Day'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'Last Market'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'Low 24 Hours'}</span>
+                </div>
+                <div className="flex-col">
+                    <span className="item">{'Low Day'}</span>
+                </div>
+            </div>
+        );
+    }
+
     render() {
         return (
-            <i />
+            <div>
+                {this.getCoinDetailHeaderRow()}
+                {this.getCoinDetailDataRow()}
+            </div>
         );
     }
 }
+
+export default MarketCapListRowDetailView;

--- a/src/components/MarketCapListRowDetailView.tsx
+++ b/src/components/MarketCapListRowDetailView.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export interface MarketCapListRowDetailViewProps {
+
+}
+
+export interface MarketCapListRowDetailViewState {
+
+}
+
+class MarketCapListRowDetailView extends
+    React.Component<MarketCapListRowDetailViewProps, MarketCapListRowDetailViewState> {
+    constructor(props: MarketCapListRowDetailViewProps) {
+        super(props);
+        this.state = {};
+    }
+    render() {
+        return (
+            <i />
+        );
+    }
+}

--- a/src/containers/MarketCapListContainer.tsx
+++ b/src/containers/MarketCapListContainer.tsx
@@ -9,12 +9,12 @@ interface StateFromProps {
     coinData: FlattenedCoinData[];
 }
 interface DispatchFromProps {
-    onClick: () => void;
+
 }
 
 export interface MarketCapListProps {
     coinData: FlattenedCoinData[];
-    onClick?: () => void;
+    onClickCoinIcon?: (tickerSymbol: string) => void;
     title: string;
 }
 
@@ -29,7 +29,6 @@ class MarketCapContainer extends React.Component<MarketCapListProps, MarketCapLi
             <div>
                 <MarketCapList
                     coinData={this.props.coinData}
-                    handleCoinIconClick={this.props.onClick}
                     title={this.props.title}
                 />
             </div>
@@ -43,7 +42,7 @@ const mapStateToProps = (state: StoreState): StateFromProps => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<actions.CryptoMarketCapListAction>): DispatchFromProps => ({
-    onClick: () => dispatch(actions.selectCoinIcon())
+
 });
 
 export default connect<MarketCapListProps, MarketCapListState, {}>(

--- a/src/reducers/cryptoMarketCapList.ts
+++ b/src/reducers/cryptoMarketCapList.ts
@@ -1,5 +1,5 @@
 import {
-    SELECT_COIN_ICON, SET_COIN_DATA, SET_AVAILABLE_COIN_LIST, SELECT_SORT_BY_MARKET_CAP,
+    SET_COIN_DATA, SET_AVAILABLE_COIN_LIST, SELECT_SORT_BY_MARKET_CAP,
     SELECT_SORT_BY_PRICE, SELECT_SORT_BY_NAME
 } from '../constants';
 import { CryptoMarketCapListAction } from '../actions/cryptoMarketCapListActions';
@@ -16,11 +16,6 @@ const initialState: CryptoMarketCapListState = {
 const cryptoMarketCapList = (state = initialState, action: CryptoMarketCapListAction | MarketCapMenuBarAction):
     CryptoMarketCapListState => {
     switch (action.type) {
-        case SELECT_COIN_ICON:
-            return {
-                ...state,
-                title: 'HI'
-            };
 
         case SET_COIN_DATA:
             return {

--- a/src/scss/_CryptoMarketCapList.scss
+++ b/src/scss/_CryptoMarketCapList.scss
@@ -1,33 +1,59 @@
+@mixin flex-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-grow: 0;
+    flex-basis: 250px;
+}
+
+@mixin flex-col {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+@mixin top-border {
+    border-top: 1px black solid;
+}
+
+@mixin top-bottom-border{
+    @include top-border;
+    border-bottom: 1px black solid;
+}
+
 .crypto-market-cap-list {
     .flex-row {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        flex-grow: 0;
-        flex-basis: 250px;
+        @include flex-row;
+        @include top-border;
         height: 80px;
+
         &-expanded {
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            flex-grow: 0;
-            flex-basis: 250px;
-            height: 160px;
+            @include flex-row;
+            @include top-border;
+            height: 400px;
+        }
+
+        &:last-child{
+            @include flex-row;
+            @include top-bottom-border;
+            height: 80px;
         }
     }
     .flex-col {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
+        @include flex-col;
         flex-grow: 0;
         flex-basis: 20%;
         &-icon{
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
+            @include flex-col;
             flex-grow: 0;
             flex-basis: 10%;
         }
+    }
+
+    .coin-detail-row{
+        @include flex-row;
+        justify-content: center;
+        margin: auto;
     }
 
     .item {
@@ -72,36 +98,32 @@
     }
 }
 
-.greenticker {
+@mixin ticker-box {
     line-height: 70px;
     text-align: center;
-    color: green;
-    border: 1px solid green;
     width: 70%;
     height: 85%;
     justify-content: center;
+}
+
+.greenticker {
+    @include ticker-box;
+    color: green;
+    border: 1px solid green;
     animation-name: red-to-green;
     animation-duration: 2s;
 }
 
 .redticker {
-    line-height: 70px;
-    text-align: center;
+    @include ticker-box;
     color: red;
     border: 1px solid red;
-    width: 70%;
-    height: 85%;
-    justify-content: center;
     animation-name: green-to-red;
     animation-duration: 2s;
 }
 
 .nochangeticker {
-    line-height: 70px;
-    text-align: center;
+    @include ticker-box;
     color: black;
     border: 1px solid black;
-    width: 70%;
-    height: 85%;
-    justify-content: center;
 }

--- a/src/scss/_CryptoMarketCapList.scss
+++ b/src/scss/_CryptoMarketCapList.scss
@@ -1,13 +1,21 @@
 .crypto-market-cap-list {
-    .flexrow {
+    .flex-row {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
         flex-grow: 0;
         flex-basis: 250px;
         height: 80px;
+        &-expanded {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            flex-grow: 0;
+            flex-basis: 250px;
+            height: 160px;
+        }
     }
-    .flexcol {
+    .flex-col {
         display: flex;
         flex-direction: column;
         justify-content: space-between;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,11 @@ export interface FlattenedCoinData {
     EUR: CoinData; 
 }
 
+export interface CoinRow {
+    coinData: FlattenedCoinData;
+    isRowExpanded: boolean;
+}
+
 export interface CryptoMarketCapListState {
     cryptos: string[];
     title: string;


### PR DESCRIPTION
1. Converted Row Component from a functional component to a class component. This way we can store the expanded prop in the state. 
2. Passing down the specific coin data to the component rather then the entire list. Previously we were passing down the entire data and making the row find its data inside the list. 
2. Refactoring the scss naming
3. Adding shell component for a detailed coin view 
